### PR TITLE
Ensure client id and secret are included in token request

### DIFF
--- a/lib/omniauth/strategies/bigcommerce.rb
+++ b/lib/omniauth/strategies/bigcommerce.rb
@@ -25,7 +25,7 @@ module OmniAuth
       option :provider_ignores_state, true
       option :scope, 'users_basic_information'
       option :authorize_options, [:scope, :context]
-      option :token_options, [:scope, :context, :account_uuid]
+      option :token_options, [:client_id, :client_secret, :scope, :context, :account_uuid]
       option :client_options,
              site: ENV.fetch('BC_AUTH_SERVICE', 'https://login.bigcommerce.com'),
              authorize_url: '/oauth2/authorize',


### PR DESCRIPTION
After a lot of digging, I realized that the change to Oauth2 v2 was causing the client id and secret to not be included with the token request. Including them here appears to solve the issue with the upgrade. I've verified that I'm able to go through the store auth/connection process and can subsequently make API calls for authentication and store info.